### PR TITLE
#23 - eth: port to prelude namespace

### DIFF
--- a/src/config/init.l
+++ b/src/config/init.l
@@ -14,7 +14,7 @@
        ()))
      (mu:open :file :input source))))
 
-(mu:intern :eth "load-core"
+(mu:intern :eth "load-prelude"
   (:lambda ()
     (mu:fix
      (:lambda (list)
@@ -23,43 +23,43 @@
              ((:lambda ()
                 (eth:load (mu:car list))
                 (mu:cdr list)))))
-   '("/opt/thorn/thorn/core/core.l"
-     "/opt/thorn/thorn/core/backquote.l"
-     "/opt/thorn/thorn/core/boole.l"
-     "/opt/thorn/thorn/core/break.l"
-     "/opt/thorn/thorn/core/compile.l"
-     "/opt/thorn/thorn/core/ctype.l"
-     "/opt/thorn/thorn/core/describe.l"
-     "/opt/thorn/thorn/core/environment.l"
-     "/opt/thorn/thorn/core/exception.l"
-     "/opt/thorn/thorn/core/fasl.l"
-     "/opt/thorn/thorn/core/fixnum.l"
-     "/opt/thorn/thorn/core/format.l"
-     "/opt/thorn/thorn/core/funcall.l"
-     "/opt/thorn/thorn/core/function.l"
-     "/opt/thorn/thorn/core/inspect.l"
-     "/opt/thorn/thorn/core/lambda.l"
-     "/opt/thorn/thorn/core/list.l"
-     "/opt/thorn/thorn/core/log.l"
-     "/opt/thorn/thorn/core/macro.l"
-     "/opt/thorn/thorn/core/map.l"
-     "/opt/thorn/thorn/core/namespace.l"
-     "/opt/thorn/thorn/core/parse.l"
-     "/opt/thorn/thorn/core/read-macro.l"
-     "/opt/thorn/thorn/core/read.l"
-     "/opt/thorn/thorn/core/repl.l"
-     "/opt/thorn/thorn/core/sequence.l"
-     "/opt/thorn/thorn/core/sort.l"
-     "/opt/thorn/thorn/core/stream.l"
-     "/opt/thorn/thorn/core/string.l"
-     "/opt/thorn/thorn/core/symbol-macro.l"
-     "/opt/thorn/thorn/core/symbol.l"
-     "/opt/thorn/thorn/core/time.l"
-     "/opt/thorn/thorn/core/type.l"
-     "/opt/thorn/thorn/core/vector.l"))))
+   '("/opt/thorn/thorn/prelude/prelude.l"
+     "/opt/thorn/thorn/prelude/backquote.l"
+     "/opt/thorn/thorn/prelude/boole.l"
+     "/opt/thorn/thorn/prelude/break.l"
+     "/opt/thorn/thorn/prelude/compile.l"
+     "/opt/thorn/thorn/prelude/ctype.l"
+     "/opt/thorn/thorn/prelude/describe.l"
+     "/opt/thorn/thorn/prelude/environment.l"
+     "/opt/thorn/thorn/prelude/exception.l"
+     "/opt/thorn/thorn/prelude/fasl.l"
+     "/opt/thorn/thorn/prelude/fixnum.l"
+     "/opt/thorn/thorn/prelude/format.l"
+     "/opt/thorn/thorn/prelude/funcall.l"
+     "/opt/thorn/thorn/prelude/function.l"
+     "/opt/thorn/thorn/prelude/inspect.l"
+     "/opt/thorn/thorn/prelude/lambda.l"
+     "/opt/thorn/thorn/prelude/list.l"
+     "/opt/thorn/thorn/prelude/log.l"
+     "/opt/thorn/thorn/prelude/macro.l"
+     "/opt/thorn/thorn/prelude/map.l"
+     "/opt/thorn/thorn/prelude/namespace.l"
+     "/opt/thorn/thorn/prelude/parse.l"
+     "/opt/thorn/thorn/prelude/read-macro.l"
+     "/opt/thorn/thorn/prelude/read.l"
+     "/opt/thorn/thorn/prelude/repl.l"
+     "/opt/thorn/thorn/prelude/sequence.l"
+     "/opt/thorn/thorn/prelude/sort.l"
+     "/opt/thorn/thorn/prelude/stream.l"
+     "/opt/thorn/thorn/prelude/string.l"
+     "/opt/thorn/thorn/prelude/symbol-macro.l"
+     "/opt/thorn/thorn/prelude/symbol.l"
+     "/opt/thorn/thorn/prelude/time.l"
+     "/opt/thorn/thorn/prelude/type.l"
+     "/opt/thorn/thorn/prelude/vector.l"))))
 
-(eth:load-core)
-(core:%init-core-ns)
+(eth:load-prelude)
+(prelude:%init-ns)
 
 ;;; inspector utilities
 (mu:intern :eth "inspect-stream" (mu:open :string :output ""))
@@ -67,87 +67,87 @@
 (mu:intern :eth "inspect"
    (:lambda (obj)
      ((:lambda (inspect)
-        (core:format
+        (prelude:format
          eth:inspect-stream
          ":type ~A~%:size ~A~%"
          `(,(mu:sv-ref (mu:st-vec inspect) 0)
            ,(mu:sv-ref (mu:st-vec inspect) 1)))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect obj))))
+        (prelude:%inspect obj))))
 
 (mu:intern :eth "inspect-tag-keys"
    (:lambda (obj)
      ((:lambda (inspect)
-        (core:mapc
+        (prelude:mapc
          (:lambda (tag)
-           (core:format
+           (prelude:format
             eth:inspect-stream
             "~A;"
             `(,(mu:car tag))))
          (mu:sv-ref (mu:st-vec inspect) 2))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect obj))))
+        (prelude:%inspect obj))))
 
 (mu:intern :eth "inspect-tag-values"
    (:lambda (obj)
      ((:lambda (inspect)
-        (core:mapc
+        (prelude:mapc
          (:lambda (tag)
-           (core:format
+           (prelude:format
             eth:inspect-stream
             "~A;"
             `(,(mu:repr :vector (mu:cdr tag)))))
          (mu:sv-ref (mu:st-vec inspect) 2))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect obj))))
+        (prelude:%inspect obj))))
 
 (mu:intern :eth "inspect-repr"
    (:lambda (repr)
      ((:lambda (inspect)
-        (core:format
+        (prelude:format
          eth:inspect-stream
          ":type ~A~%:size ~A~%"
          `(,(mu:sv-ref (mu:st-vec inspect) 0)
            ,(mu:sv-ref (mu:st-vec inspect) 1)))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect (mu:repr :t repr)))))
+        (prelude:%inspect (mu:repr :t repr)))))
 
 (mu:intern :eth "inspect-repr-tag-keys"
    (:lambda (repr)
      ((:lambda (inspect)
-        (core:mapc
+        (prelude:mapc
          (:lambda (tag)
-           (core:format
+           (prelude:format
             eth:inspect-stream
             "~A;"
             `(,(mu:car tag))))
          (mu:sv-ref (mu:st-vec inspect) 2))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect (mu:repr :t repr)))))
+        (prelude:%inspect (mu:repr :t repr)))))
 
 (mu:intern :eth "inspect-repr-tag-values"
    (:lambda (repr)
      ((:lambda (inspect)
-        (core:mapc
+        (prelude:mapc
          (:lambda (tag)
-           (core:format
+           (prelude:format
             eth:inspect-stream
             "~A;"
             `(,(mu:repr :vector (mu:cdr tag)))))
          (mu:sv-ref (mu:st-vec inspect) 2))
         (mu:get-str eth:inspect-stream))
-        (core:%inspect (mu:repr :t repr)))))
+        (prelude:%inspect (mu:repr :t repr)))))
 
 ;;; json utilities
 (mu:intern :eth "json-cmd-stream" (mu:open :string :output ""))
 
 (mu:intern :eth "write-json"
   (:lambda (form stream)
-    (:if (core:stringp form)
-         (core:format stream "~S" `(,form))
-         (:if (core:vectorp form)
+    (:if (prelude:stringp form)
+         (prelude:format stream "~S" `(,form))
+         (:if (prelude:vectorp form)
               ((:lambda (len)
-                  (core:format stream "[ " ())
+                  (prelude:format stream "[ " ())
                   (mu:fix
                    (:lambda (nth)
                       (:if (mu:eq nth len)
@@ -155,20 +155,20 @@
                            (:if (mu:fx-lt nth len)
                                 ((:lambda ()
                                     (eth:write-json (mu:sv-ref form nth) stream)
-                                    (:if (mu:fx-lt nth (core:1- len))
-                                         (core:format stream ", " ())                           
+                                    (:if (mu:fx-lt nth (prelude:1- len))
+                                         (prelude:format stream ", " ())                           
                                          ())
-                                    (core:1+ nth)))
+                                    (prelude:1+ nth)))
                                 nth)))
                    0)
-                  (core:format stream " ]" ()))
+                  (prelude:format stream " ]" ()))
                (mu:sv-len form))
-              (:if (core:dottedp form)
+              (:if (prelude:dottedp form)
                    ((:lambda ()
-                       (core:format stream "{ ~S : " `(,(mu:car form)))
+                       (prelude:format stream "{ ~S : " `(,(mu:car form)))
                        (eth:write-json (mu:cdr form) stream)
-                       (core:format stream " }" ())))
-                   (core:format stream " ~S " `(,form)))))))
+                       (prelude:format stream " }" ())))
+                   (prelude:format stream " ~S " `(,form)))))))
 
 ;;; scratchpad functions
 (mu:intern :eth "defbutton"

--- a/src/eth/tabs/about.rs
+++ b/src/eth/tabs/about.rs
@@ -122,7 +122,7 @@ impl AboutTab {
             Space::new(width as u16, 5),
             text(format!("mu: version: {}", Mu::VERSION)).size(20),
             text(format!(
-                "core: heap size (pages) : {}",
+                "mu: heap size (pages) : {}",
                 env.core
                     .as_ref()
                     .unwrap()

--- a/src/eth/tabs/listener.rs
+++ b/src/eth/tabs/listener.rs
@@ -1,7 +1,7 @@
 //  SPDX-FileCopyrightText: Copyright 2023 James M. Putnam (putnamjm.design@gmail.com)
 //  SPDX-License-Identifier: MIT
 
-// core panel
+// listener panel
 //
 #![allow(clippy::new_without_default)]
 #![allow(clippy::collapsible_match)]
@@ -45,7 +45,7 @@ impl ListenerTab {
     pub fn new() -> Self {
         let tty = TtyBuilder::new().rows(19).cursor('_').build();
 
-        tty.write_string("core> ".to_string());
+        tty.write_string("eth> ".to_string());
 
         ListenerTab {
             command: String::new(),


### PR DESCRIPTION
now works with the new thorn prelude library